### PR TITLE
Debugger fixes (R-Host)

### DIFF
--- a/src/Rapi.h
+++ b/src/Rapi.h
@@ -332,6 +332,13 @@ extern "C" {
     extern SEXP CDR(SEXP e);
     extern SEXP SETCDR(SEXP x, SEXP y);
 
+    extern int RDEBUG(SEXP x);
+    extern int RSTEP(SEXP x);
+    extern int RTRACE(SEXP x);
+    extern void SET_RDEBUG(SEXP x, int v);
+    extern void SET_RSTEP(SEXP x, int v);
+    extern void SET_RTRACE(SEXP x, int v);
+
 #ifdef _WIN32
     extern char *getDLLVersion(void), *getRUser(void), *get_R_HOME(void);
     extern void setup_term_ui(void);

--- a/src/eval.h
+++ b/src/eval.h
@@ -60,6 +60,10 @@ namespace rhost {
                         FAfter& after;
                     } eval_data = { VECTOR_ELT(sexp_parsed.get(), i), env, result, before, after };
 
+                    // Reset debug flag to avoid eval entering Browse mode.
+                    int rdebug = RDEBUG(env);
+                    SET_RDEBUG(env, 0);
+
                     auto protected_eval = [](void* pdata) {
                         auto& eval_data = *static_cast<eval_data_t*>(pdata);
                         eval_data.before();
@@ -67,6 +71,9 @@ namespace rhost {
                         eval_data.result.value.reset(Rf_eval(eval_data.expr, eval_data.env));
                         eval_data.after();
                     };
+
+                    // Restore debug flag.
+                    SET_RDEBUG(env, rdebug);
 
                     result.has_error = !R_ToplevelExec(protected_eval, &eval_data);
                     result.is_canceled = was_eval_canceled;

--- a/src/r_util.cpp
+++ b/src/r_util.cpp
@@ -373,6 +373,15 @@ namespace rhost {
             });
         }
 
+        extern "C" SEXP is_rdebug(SEXP obj) {
+            return RDEBUG(obj) ? R_TrueValue : R_FalseValue;
+        }
+
+        extern "C" SEXP set_rdebug(SEXP obj, SEXP debug) {
+            SET_RDEBUG(obj, Rf_asLogical(debug));
+            return R_NilValue;
+        }
+
         R_CallMethodDef call_methods[] = {
             { "rtvs::Call.unevaluated_promise", (DL_FUNC)unevaluated_promise, 2 },
             { "rtvs::Call.memory_connection", (DL_FUNC)memory_connection_new, 4 },
@@ -381,6 +390,8 @@ namespace rhost {
             { "rtvs::Call.send_message", (DL_FUNC)send_message, 2 },
             { "rtvs::Call.send_message_and_get_response", (DL_FUNC)send_message_and_get_response, 2 },
             { "rtvs::Call.set_instrumentation_callback", (DL_FUNC)set_instrumentation_callback, 1 },
+            { "rtvs::Call.is_rdebug", (DL_FUNC)is_rdebug, 1 },
+            { "rtvs::Call.set_rdebug", (DL_FUNC)set_rdebug, 2 },
             { }
         };
 


### PR DESCRIPTION
Clear debug flag on environment during eval, to avoid entering Browse mode when evaluating during step-in.

Expose functions to query and change the debug flag from R code.
