### PR TITLE
Fix log collisions (R-Host)

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -25,7 +25,7 @@
 
 namespace rhost {
     namespace log {
-        void init_log();
+        void init_log(const std::string& log_suffix);
 
         void vlogf(const char* format, va_list va);
 


### PR DESCRIPTION
Allow host processes to be optionally named (reflected in log file name).

Include current process ID in log file name to avoid collisions between different VS instances.
