### PR TITLE
Remove references to VS from R-Host source code.

### DIFF
--- a/src/grdeviceside.cpp
+++ b/src/grdeviceside.cpp
@@ -816,11 +816,11 @@ namespace rhost {
             }
 
             static R_ExternalMethodDef external_methods[] = {
-                { "rtvs::External.ide_graphicsdevice_new", (DL_FUNC)&ide_graphicsdevice_new, 0 },
-                { "rtvs::External.ide_graphicsdevice_resize", (DL_FUNC)&ide_graphicsdevice_resize, 2 },
-                { "rtvs::External.ide_graphicsdevice_next_plot", (DL_FUNC)&ide_graphicsdevice_next_plot, 0 },
-                { "rtvs::External.ide_graphicsdevice_previous_plot", (DL_FUNC)&ide_graphicsdevice_previous_plot, 0 },
-                { "rtvs::External.ide_graphicsdevice_history_info", (DL_FUNC)&ide_graphicsdevice_history_info, 0 },
+                { "Microsoft.R.Host::External.ide_graphicsdevice_new", (DL_FUNC)&ide_graphicsdevice_new, 0 },
+                { "Microsoft.R.Host::External.ide_graphicsdevice_resize", (DL_FUNC)&ide_graphicsdevice_resize, 2 },
+                { "Microsoft.R.Host::External.ide_graphicsdevice_next_plot", (DL_FUNC)&ide_graphicsdevice_next_plot, 0 },
+                { "Microsoft.R.Host::External.ide_graphicsdevice_previous_plot", (DL_FUNC)&ide_graphicsdevice_previous_plot, 0 },
+                { "Microsoft.R.Host::External.ide_graphicsdevice_history_info", (DL_FUNC)&ide_graphicsdevice_history_info, 0 },
                 {}
             };
 

--- a/src/grdevicesxaml.cpp
+++ b/src/grdevicesxaml.cpp
@@ -505,7 +505,7 @@ namespace rhost {
             }
 
             static R_ExternalMethodDef external_methods[] = {
-                { "rtvs::External.xaml_graphicsdevice_new", (DL_FUNC)&xaml_graphicsdevice_new, 3 },
+                { "Microsoft.R.Host::External.xaml_graphicsdevice_new", (DL_FUNC)&xaml_graphicsdevice_new, 3 },
                 { }
             };
 

--- a/src/r_util.cpp
+++ b/src/r_util.cpp
@@ -383,15 +383,15 @@ namespace rhost {
         }
 
         R_CallMethodDef call_methods[] = {
-            { "rtvs::Call.unevaluated_promise", (DL_FUNC)unevaluated_promise, 2 },
-            { "rtvs::Call.memory_connection", (DL_FUNC)memory_connection_new, 4 },
-            { "rtvs::Call.memory_connection_tochar", (DL_FUNC)memory_connection_tochar, 1 },
-            { "rtvs::Call.memory_connection_overflown", (DL_FUNC)memory_connection_overflown, 1 },
-            { "rtvs::Call.send_message", (DL_FUNC)send_message, 2 },
-            { "rtvs::Call.send_message_and_get_response", (DL_FUNC)send_message_and_get_response, 2 },
-            { "rtvs::Call.set_instrumentation_callback", (DL_FUNC)set_instrumentation_callback, 1 },
-            { "rtvs::Call.is_rdebug", (DL_FUNC)is_rdebug, 1 },
-            { "rtvs::Call.set_rdebug", (DL_FUNC)set_rdebug, 2 },
+            { "Microsoft.R.Host::Call.unevaluated_promise", (DL_FUNC)unevaluated_promise, 2 },
+            { "Microsoft.R.Host::Call.memory_connection", (DL_FUNC)memory_connection_new, 4 },
+            { "Microsoft.R.Host::Call.memory_connection_tochar", (DL_FUNC)memory_connection_tochar, 1 },
+            { "Microsoft.R.Host::Call.memory_connection_overflown", (DL_FUNC)memory_connection_overflown, 1 },
+            { "Microsoft.R.Host::Call.send_message", (DL_FUNC)send_message, 2 },
+            { "Microsoft.R.Host::Call.send_message_and_get_response", (DL_FUNC)send_message_and_get_response, 2 },
+            { "Microsoft.R.Host::Call.set_instrumentation_callback", (DL_FUNC)set_instrumentation_callback, 1 },
+            { "Microsoft.R.Host::Call.is_rdebug", (DL_FUNC)is_rdebug, 1 },
+            { "Microsoft.R.Host::Call.set_rdebug", (DL_FUNC)set_rdebug, 2 },
             { }
         };
 

--- a/src/xamlbuilder.h
+++ b/src/xamlbuilder.h
@@ -29,9 +29,6 @@
 
 #define XAML_XMLNS "http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 
-// Re-enable this code if we want to use base-64 encoded bitmaps (with appropriate namespace/assembly name)
-//#define VS_XMLNS "clr-namespace:Microsoft.VisualStudioTools.Wpf;assembly=XamlViewer"
-
 namespace rhost {
     namespace graphics {
         class xaml_builder {
@@ -162,38 +159,6 @@ namespace rhost {
                 _xaml.push_back(stream.str());
             }
 
-            // TODO: currently unused, not sure if we'll end up using it or not.  keeping in case we do.
-            //void bitmap_embedded_base64(double top, double left, double width, double height, double rotation, bool interpolate, const std::string& base64_encoded_data) {
-            //    std::ostringstream stream;
-
-            //    stream << "<Image";
-            //    write_attr("Canvas.Left", left, stream);
-            //    write_attr("Canvas.Top", top, stream);
-            //    write_attr("Width", width, stream);
-            //    write_attr("Height", height, stream);
-            //    if (!interpolate) {
-            //        stream << " RenderOptions.BitmapScalingMode=\"NearestNeighbor\"";
-            //    }
-            //    stream << " >";
-            //    if (rotation != 0) {
-            //        stream << "<Image.RenderTransform>";
-            //        stream << "<TransformGroup>";
-            //        stream << "<RotateTransform Angle=\"" << rotation << "\" />";
-            //        stream << "</TransformGroup>";
-            //        stream << "</Image.RenderTransform>";
-            //    }
-            //    stream << "<Image.Source>";
-            //    stream << "<vs:Base64ImageSource>";
-            //    stream << "<vs:Base64ImageSource.Base64>";
-            //    stream << base64_encoded_data;
-            //    stream << "</vs:Base64ImageSource.Base64>";
-            //    stream << "</vs:Base64ImageSource>";
-            //    stream << "</Image.Source>";
-            //    stream << "</Image>";
-
-            //    _xaml.push_back(stream.str());
-            //}
-
             void bitmap_external_file(double top, double left, double width, double height, double rotation, bool interpolate, const std::string& filepath) {
                 std::ostringstream stream;
 
@@ -283,8 +248,6 @@ namespace rhost {
             void write_xaml(std::ofstream& f) {
                 f << "<Canvas";
                 write_attr("xmlns", "http://schemas.microsoft.com/winfx/2006/xaml/presentation", f);
-                // Re-enable this code if we want to use base-64 encoded bitmaps
-                //write_attr("xmlns:vs", VS_XMLNS, f);
                 write_attr("Height", _height, f);
                 write_attr("Width", _width, f);
                 write_attr("Background", _background_color, f);


### PR DESCRIPTION
Also remove commented-out base64-based bitmap transmission code from XAML graphics device.
