### PR TITLE
Fix #621: Step In on a line with breakpoint breaks things [R-Host]

### DIFF
--- a/src/Rapi.h
+++ b/src/Rapi.h
@@ -307,6 +307,7 @@ extern "C" {
     extern SEXP Rf_install(const char*);
     extern SEXP Rf_installChar(SEXP);
     extern SEXP Rf_classgets(SEXP, SEXP);
+    extern SEXP Rf_NewEnvironment(SEXP, SEXP, SEXP);
 
     extern void setup_Rmainloop(void);
     extern void run_Rmainloop(void);


### PR DESCRIPTION
Introduce the concept of a "protected environment" - use a throw-away dummy environment as evaluation context, with designated target environment set as a parent of the dummy, to avoid issues when debug bit is set on the environment (e.g. after stepping). Evaluations are protected by default, but a flag to request unprotected eval is provided.
