### PR TITLE
Rename "protected environment" flag to "new environment", and don't use it for evals by default.

### DIFF
--- a/src/host.cpp
+++ b/src/host.cpp
@@ -171,7 +171,7 @@ namespace rhost {
 
             const auto& expr = from_utf8(msg.args[0].get<std::string>());
             SEXP env = nullptr;
-            bool is_cancelable = false, json_result = false, protect_env = true;
+            bool is_cancelable = false, json_result = false, new_env = false;
 
             for (auto it = msg.name.begin() + 1; it != msg.name.end(); ++it) {
                 switch (char c = *it) {
@@ -182,8 +182,8 @@ namespace rhost {
                     }
                     env = (c == 'B') ? R_BaseEnv : R_EmptyEnv;
                     break;
-                case 'U':
-                    protect_env = false;
+                case 'N':
+                    new_env = true;
                     break;
                 case 'j':
                     json_result = true;
@@ -236,7 +236,7 @@ namespace rhost {
                     was_after_invoked = true;
                 };
 
-                protected_sexp eval_env(protect_env ? Rf_NewEnvironment(R_NilValue, R_NilValue, env) : env);
+                protected_sexp eval_env(new_env ? Rf_NewEnvironment(R_NilValue, R_NilValue, env) : env);
                 result = r_try_eval_str(expr, eval_env.get(), ps, before, after);
 
                 // If eval was canceled, the "after" block was never executed (since it is normally run within the eval


### PR DESCRIPTION
This basically reverts the change https://github.com/Microsoft/RTVS/pull/632, at least as far as default behavior is concerned.

The reason is that this extra layer of protection was actually superfluous - @huguesv has found that the first layer (the one which clears the debug flag on the environment and then restores it: https://github.com/int19h/R-Host/blob/8d183c1c27747d491392aaca7ed7ce25c7db34ce/src/eval.h#L65) had a bug in it that resulted in the flag being restored before the actual eval, which is why the problem was manifesting. Adding the extra layer "fixed" it by dodging the incorrectly set bit, but the proper fix was to just fix the flag clearing, which is what @huguesv did in https://github.com/Microsoft/R-Host/commit/3a93cfc3e60c06857d1759a830fee754ff694f84.

So now this protection layer is not doing anything useful, but on the other hand it's complicating the semantics (because you can't do direct assignments etc). Hence the removal. I have also verified that the original bug that prompted me to add it no longer repros even without it, as expected.

I'm still keeping it as an option under a new name because it might still be occasionally useful for other things - it's basically the equivalent to `local({ ... })` that is more lightweight and more foolproof.
