### PR TITLE
Plot error handling

### DIFF
--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -31,6 +31,7 @@
 #include <filesystem>
 #include <fstream>
 #include <future>
+#include <iostream>
 #include <memory>
 #include <mutex>
 #include <string>

--- a/src/util.h
+++ b/src/util.h
@@ -172,7 +172,7 @@ namespace rhost {
             return true;
         }
 
-        class r_error : std::runtime_error {
+        class r_error : public std::runtime_error {
         public:
             explicit r_error(const std::string& msg)
                 : std::runtime_error(msg) {


### PR DESCRIPTION
Fix inheritance of r_error class. This was preventing the catch statements for std::exception from catching any r_error, thus bringing the process down.

Ensure that replay state is restored in the face of exceptions.
When an error occur, create and send an empty file to VS so that it clears the plot currently displayed.
