### PR TITLE
Store snapshot objects in C++ plot object

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -103,11 +103,8 @@ namespace rhost {
             using unique_ptr::operator=;
 
             protected_sexp& operator= (SEXP other) {
-                return *this = std::move(protected_sexp(other));
-            }
-
-            protected_sexp& operator= (const protected_sexp& other) {
-                return *this = other.get();
+                swap(protected_sexp(other));
+                return *this;
             }
         };
 


### PR DESCRIPTION
DON'T MERGE UNTIL BUG IS APPROVED: https://github.com/Microsoft/RTVS/issues/886

Stop unnecessarily saving the snapshot objects in the R session.  It's sufficient to keep the SEXP in the C++ plot object.

Fix implementation of equal operator of protected_sexp, and remove the one that was unused.  The way they were implemented previously, they kept calling each other until you got an exception.
