### PR TITLE
Fix #560: BxlServer.exe opens console window

### DIFF
--- a/src/Microsoft.R.Host.vcxproj
+++ b/src/Microsoft.R.Host.vcxproj
@@ -158,7 +158,7 @@
       <AdditionalIncludeDirectories>..\lib\picojson;..\lib\websocketpp</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
-      <SubSystem>Windows</SubSystem>
+      <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>


### PR DESCRIPTION
Always use console subsystem for R-Host. This prevents a weird corner case where code in the host process doing CreateProcess(SW_HIDE) on a second console process not actually respecting SW_HIDE flag.
