### PR TITLE
Snapshot storage

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -103,11 +103,8 @@ namespace rhost {
             using unique_ptr::operator=;
 
             protected_sexp& operator= (SEXP other) {
-                return *this = std::move(protected_sexp(other));
-            }
-
-            protected_sexp& operator= (const protected_sexp& other) {
-                return *this = other.get();
+                swap(protected_sexp(other));
+                return *this;
             }
         };
 

--- a/src/util.h
+++ b/src/util.h
@@ -106,6 +106,15 @@ namespace rhost {
                 swap(protected_sexp(other));
                 return *this;
             }
+
+            protected_sexp& operator= (const protected_sexp& other) {
+                return *this = other.get();
+            }
+
+            protected_sexp& operator= (protected_sexp&& other) {
+                swap(other);
+                return *this;
+            }
         };
 
         std::string to_utf8(const char* buf, size_t len);


### PR DESCRIPTION
Store snapshots in c++ objects, and fix issue in equal operator of protected_sexp.
This is an identical resubmission of https://github.com/Microsoft/R-Host/pull/33 from my new fork.
