### PR TITLE
Relax graphics engine version check to allow R 3.2 and 3.3

### DIFF
--- a/src/Rgraphicsapi.h
+++ b/src/Rgraphicsapi.h
@@ -41,6 +41,9 @@
 
 #define R_GE_version 10
 
+#define R_32_GE_version 10
+#define R_33_GE_version 11
+
 #define R_RGB(r,g,b)        ((r)|((g)<<8)|((b)<<16)|0xFF000000)
 #define R_RGBA(r,g,b,a)     ((r)|((g)<<8)|((b)<<16)|((a)<<24))
 #define R_RED(col)          (((col))&255)

--- a/src/grdeviceside.cpp
+++ b/src/grdeviceside.cpp
@@ -824,9 +824,12 @@ namespace rhost {
             ///////////////////////////////////////////////////////////////////////
 
             extern "C" SEXP ide_graphicsdevice_new(SEXP args) {
-                return rhost::util::exceptions_to_errors([&] {
-                    R_GE_checkVersionOrDie(R_GE_version);
+                int ver = R_GE_getVersion();
+                if (ver < R_32_GE_version || ver > R_33_GE_version) {
+                    Rf_error("Graphics API version %d is not supported.", ver);
+                }
 
+                return rhost::util::exceptions_to_errors([&] {
                     if (device_instance != nullptr) {
                         // TODO: issue some error
                         return R_NilValue;

--- a/src/grdevicesxaml.cpp
+++ b/src/grdevicesxaml.cpp
@@ -490,7 +490,10 @@ namespace rhost {
                 double *w = REAL(width);
                 double *h = REAL(height);
 
-                R_GE_checkVersionOrDie(R_GE_version);
+                int ver = R_GE_getVersion();
+                if (ver < R_32_GE_version || ver > R_33_GE_version) {
+                    Rf_error("Graphics API version %d is not supported.", ver);
+                }
 
                 R_CheckDeviceAvailable();
                 BEGIN_SUSPEND_INTERRUPTS{


### PR DESCRIPTION
I've verified that the public graphics engine/device structs that we compile against haven't changed in R 3.3, so we can run on both 3.2 and 3.3 without any conditional code.

Edit: Removed don't merge warning, since this is for public preview milestone.