### PR TITLE
Host crash on navigation to invalid plot

### DIFF
--- a/src/grdeviceside.cpp
+++ b/src/grdeviceside.cpp
@@ -273,11 +273,11 @@ namespace rhost {
                 try {
                     rhost::util::errors_to_exceptions([&] {
                         auto snapshot = _snapshot.get();
-                        if (snapshot != R_UnboundValue && snapshot != R_NilValue) {
+                        if (snapshot != nullptr && snapshot != R_UnboundValue && snapshot != R_NilValue) {
                             pGEDevDesc ge_dev_desc = Rf_desc2GEDesc(_device_desc);
                             GEplaySnapshot(snapshot, ge_dev_desc);
                         } else {
-                            Rf_error("Plot snapshot is missing. Plot history may be corrupted. You should restart your session.");
+                            render_empty();
                         }
                     });
                 } catch (rhost::util::r_error&) {


### PR DESCRIPTION
Check for nullptr on the plot snapshot. Remove warning about plot history corruption, as that was for the case where the user tempered with the internal session variables which don't exist anymore.

Fix for https://github.com/Microsoft/RTVS/issues/1021
