### PR TITLE
Make JSON serialization errors non-fatal

### DIFF
--- a/src/host.cpp
+++ b/src/host.cpp
@@ -294,7 +294,11 @@ namespace rhost {
             }
             if (result.has_value) {
                 if (json_result) {
-                    to_json(result.value.get(), value);
+                    try {
+                        errors_to_exceptions([&] { to_json(result.value.get(), value); });
+                    } catch (r_error& err) {
+                        fatal_error("%s", err.what());
+                    }
                 } else {
                     value = to_utf8_json(R_CHAR(Rf_asChar(result.value.get())));
                 }

--- a/src/json.h
+++ b/src/json.h
@@ -41,11 +41,14 @@ namespace rhost {
         // Any input not covered by the rules above is considered invalid.
         //
         // Returns true if serialized value was NA, and false otherwise (even if it contains NA somewhere inside).
+        // Errors are reported via Rf_error.
         bool to_json(SEXP sexp, picojson::value& result);
 
+        // Same as above, but value is returned directly instead of being constructed in the provided location,
+        // and errors are reported as C++ exceptions.
         inline picojson::value to_json(SEXP sexp) {
             picojson::value result;
-            to_json(sexp, result);
+            rhost::util::errors_to_exceptions([&] { to_json(sexp, result); });
             return result;
         }
     }


### PR DESCRIPTION
Make JSON serialization errors non-fatal in the serializer itself (failing to serialize JSON result for `=j` eval is still fatal, but errors from `toJSON` can now be handled).

Reorganize JSON serializer error messages for better readability.