### PR TITLE
Fix #1493: BeginInteractionAsync deadlock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,3 +83,5 @@ UpgradeLog*.htm
 *.opensdf
 src/GeneratedVersion.h
 src/Microsoft.R.Host.VC.opendb
+src/Microsoft.R.Host.VC.VC.opendb
+src/Microsoft.R.Host.VC.db

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,7 @@ namespace rhost {
             connect("rhost-connect", po::value<websocketpp::uri>(), "Connect to a websocket server at the specified URI.");
 
         po::options_description desc;
-        for (auto&& opt : { help, name, listen, connect }) {
+        for (auto&& opt : { help, name, /*listen,*/ connect }) {
             boost::shared_ptr<po::option_description> popt(new po::option_description(opt));
             desc.add(popt);
         }


### PR DESCRIPTION
When receiving messages, do not overwrite the global variable used to store request response with eval and cancellation messages. Also, refactor code, renaming variables and adding comments to make it clearer which is used where, and separating mutexes for various unrelated things.

Disable `--rhost-listen` (host server mode) until that code path is properly analyzed and vetted on security.

Add VS2015 U2 C++ Intellisense database files to .gitignore.