### PR TITLE
Fix #1340: Non-ASCII output is garbled when R locale is not Latin-1

### DIFF
--- a/src/msvcrt.cpp
+++ b/src/msvcrt.cpp
@@ -40,5 +40,7 @@ namespace rhost {
         MSVCRT_EXPORT(free);
         MSVCRT_EXPORT(atexit);
         MSVCRT_EXPORT(vsnprintf);
+        MSVCRT_EXPORT(mbstowcs);
+        MSVCRT_EXPORT(wctomb);
     }
 }

--- a/src/msvcrt.cpp
+++ b/src/msvcrt.cpp
@@ -42,5 +42,6 @@ namespace rhost {
         MSVCRT_EXPORT(vsnprintf);
         MSVCRT_EXPORT(mbstowcs);
         MSVCRT_EXPORT(wctomb);
+        MSVCRT_EXPORT(mbtowc);
     }
 }

--- a/src/msvcrt.h
+++ b/src/msvcrt.h
@@ -30,5 +30,7 @@ namespace rhost {
         extern void (*free)(void *memblock);
         extern int (*atexit)(void(*func)(void));
         extern int (*vsnprintf)(char*, size_t, const char*, va_list);
+        extern int (*mbstowcs)(wchar_t*, const char*, size_t);
+        extern int (*wctomb)(char*, wchar_t);
     }
 }

--- a/src/msvcrt.h
+++ b/src/msvcrt.h
@@ -32,5 +32,6 @@ namespace rhost {
         extern int (*vsnprintf)(char*, size_t, const char*, va_list);
         extern int (*mbstowcs)(wchar_t*, const char*, size_t);
         extern int (*wctomb)(char*, wchar_t);
+        extern int (*mbtowc)(wchar_t*, const char*, size_t);
     }
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -22,6 +22,7 @@
 
 #include "stdafx.h"
 #include "util.h"
+#include "msvcrt.h"
 
 namespace po = boost::program_options;
 
@@ -68,7 +69,7 @@ namespace rhost {
 
             if ((pb = strchr(s, UTF8in[0])) && *(pb + 1) == UTF8in[1] && *(pb + 2) == UTF8in[2]) {
                 *pb = '\0';
-                nc += mbstowcs(wc, s, n);
+                nc += msvcrt::mbstowcs(wc, s, n);
                 pb += 3; pe = pb;
 
                 while (*pe &&
@@ -86,7 +87,7 @@ namespace rhost {
                 pe += 3;
                 nc += RString2Unicode(wc + nc, pe, n - nc);
             } else {
-                nc = mbstowcs(wc, s, n);
+                nc = msvcrt::mbstowcs(wc, s, n);
             }
             return nc;
         }
@@ -124,7 +125,7 @@ namespace rhost {
             for (size_t i = 0; i < ws.length(); i++)
             {
                 char mbcharbuf[8];
-                int mbcch = wctomb(mbcharbuf, ws[i]);
+                int mbcch = msvcrt::wctomb(mbcharbuf, ws[i]);
                 if (mbcch == -1) {
                     // Character could not be converted, encode it
                     sprintf(&converted[j], "\\u%04x", ws[i]);


### PR DESCRIPTION
Use mbstowcs and wctomb from MinGW, rather than from VC, when converting to/from UTF-8, so as to respect MinGW (and hence R) locale.