### PR TITLE
Don't force create file device when resizing, to prevent creating an …

### DIFF
--- a/src/grdeviceside.cpp
+++ b/src/grdeviceside.cpp
@@ -664,8 +664,6 @@ namespace rhost {
                 _width = width;
                 _height = height;
 
-                _file_device = create_file_device();
-
                 _history.resize(width, height);
             }
 


### PR DESCRIPTION
…empty png file that isn't tracked.

Fixes https://github.com/Microsoft/RTVS/issues/1568