### PR TITLE
Remove the distinction between non-JSON and JSON evals

### DIFF
--- a/src/host.cpp
+++ b/src/host.cpp
@@ -227,7 +227,7 @@ namespace rhost {
             log::logf("%s = %s\n\n", msg.id.c_str(), expr.c_str());
 
             SEXP env = nullptr;
-            bool is_cancelable = false, json_result = false, new_env = false, no_result = false;
+            bool is_cancelable = false, new_env = false, no_result = false;
 
             for (auto it = msg.name.begin() + 1; it != msg.name.end(); ++it) {
                 switch (char c = *it) {
@@ -240,9 +240,6 @@ namespace rhost {
                     break;
                 case 'N':
                     new_env = true;
-                    break;
-                case 'j':
-                    json_result = true;
                     break;
                 case '@':
                     allow_callbacks = true;
@@ -347,14 +344,10 @@ namespace rhost {
                 error = picojson::value(to_utf8(result.error));
             }
             if (result.has_value && !no_result) {
-                if (json_result) {
-                    try {
-                        errors_to_exceptions([&] { to_json(result.value.get(), value); });
-                    } catch (r_error& err) {
-                        fatal_error("%s", err.what());
-                    }
-                } else {
-                    value = to_utf8_json(R_CHAR(Rf_asChar(result.value.get())));
+                try {
+                    errors_to_exceptions([&] { to_json(result.value.get(), value); });
+                } catch (r_error& err) {
+                    fatal_error("%s", err.what());
                 }
             }
 


### PR DESCRIPTION
Rationale:

The two different modes were necessary originally because JSON evals returned already serialized JSON from R as string, and so the flag served to tell host code to parse that.

Since that had changed, and serialization for JSON evals always happens on the host side now, the only practical difference is that a non-JSON evaluation will have its result implicitly converted to a string via `Rf_asChar`. The problem is that this function 1) doesn't behave quite like anything you might call from R, and 2) silently discards data when converting (e.g. multi-element vector will have all but the first elements discarded).

A better approach is to specify the conversion as part of the R expression (where necessary, since e.g. most primitive types like booleans will simply be serialized to JSON as such), which gives the caller full control over how it's handled, and which is explicit when reading the code. Hence this change.