### PR TITLE
Plot

### DIFF
--- a/src/grdeviceside.cpp
+++ b/src/grdeviceside.cpp
@@ -931,27 +931,6 @@ namespace rhost {
                 });
             }
 
-            extern "C" SEXP ide_graphicsdevice_history_info(SEXP args) {
-                return rhost::util::exceptions_to_errors([&] {
-                    // zero-based index of active plot, number of plots
-                    auto plotIndex = Rf_allocVector(INTSXP, 1);
-                    auto plotCount = Rf_allocVector(INTSXP, 1);
-
-                    if (device_instance != nullptr) {
-                        *INTEGER(plotIndex) = device_instance->active_plot_index();
-                        *INTEGER(plotCount) = device_instance->plot_count();
-                    } else {
-                        *INTEGER(plotIndex) = -1;
-                        *INTEGER(plotCount) = 0;
-                    }
-
-                    auto value = Rf_allocVector(VECSXP, 2);
-                    SET_VECTOR_ELT(value, 0, plotIndex);
-                    SET_VECTOR_ELT(value, 1, plotCount);
-                    return value;
-                });
-            }
-
             extern "C" SEXP ide_graphicsdevice_clear_plots(SEXP args) {
                 return rhost::util::exceptions_to_errors([&] {
                     if (device_instance != nullptr) {
@@ -981,7 +960,6 @@ namespace rhost {
                 { "Microsoft.R.Host::External.ide_graphicsdevice_resize", (DL_FUNC)&ide_graphicsdevice_resize, 3 },
                 { "Microsoft.R.Host::External.ide_graphicsdevice_next_plot", (DL_FUNC)&ide_graphicsdevice_next_plot, 0 },
                 { "Microsoft.R.Host::External.ide_graphicsdevice_previous_plot", (DL_FUNC)&ide_graphicsdevice_previous_plot, 0 },
-                { "Microsoft.R.Host::External.ide_graphicsdevice_history_info", (DL_FUNC)&ide_graphicsdevice_history_info, 0 },
                 { "Microsoft.R.Host::External.ide_graphicsdevice_clear_plots", (DL_FUNC)&ide_graphicsdevice_clear_plots, 0 },
                 { "Microsoft.R.Host::External.ide_graphicsdevice_remove_plot", (DL_FUNC)&ide_graphicsdevice_remove_plot, 0 },
                 {}

--- a/src/grdeviceside.cpp
+++ b/src/grdeviceside.cpp
@@ -711,8 +711,8 @@ namespace rhost {
                     rhost::host::send_message(
                         "Plot",
                         rhost::util::to_utf8(path_copy.make_preferred().string()),
-                        (double)active_plot_index(),
-                        (double)plot_count()
+                        static_cast<double>(active_plot_index()),
+                        static_cast<double>(plot_count())
                     );
                 });
             }

--- a/src/grdeviceside.cpp
+++ b/src/grdeviceside.cpp
@@ -708,7 +708,12 @@ namespace rhost {
             void ide_device::send(const std::tr2::sys::path& filename) {
                 auto path_copy(filename);
                 rhost::host::with_cancellation([&] {
-                    rhost::host::send_message("Plot", rhost::util::to_utf8(path_copy.make_preferred().string()));
+                    rhost::host::send_message(
+                        "Plot",
+                        rhost::util::to_utf8(path_copy.make_preferred().string()),
+                        (double)active_plot_index(),
+                        (double)plot_count()
+                    );
                 });
             }
 
@@ -895,6 +900,7 @@ namespace rhost {
                     if (device_instance != nullptr) {
                         device_instance->select();
                         device_instance->resize(*w, *h, *res);
+                        device_instance->render_request(true);
                     }
 
                     return R_NilValue;
@@ -906,6 +912,7 @@ namespace rhost {
                     if (device_instance != nullptr) {
                         device_instance->select();
                         device_instance->history_next();
+                        device_instance->render_request(true);
                     }
 
                     return R_NilValue;
@@ -917,6 +924,7 @@ namespace rhost {
                     if (device_instance != nullptr) {
                         device_instance->select();
                         device_instance->history_previous();
+                        device_instance->render_request(true);
                     }
 
                     return R_NilValue;
@@ -949,6 +957,7 @@ namespace rhost {
                     if (device_instance != nullptr) {
                         device_instance->select();
                         device_instance->history_clear();
+                        device_instance->render_request(true);
                     }
 
                     return R_NilValue;
@@ -960,6 +969,7 @@ namespace rhost {
                     if (device_instance != nullptr) {
                         device_instance->select();
                         device_instance->history_remove_active();
+                        device_instance->render_request(true);
                     }
 
                     return R_NilValue;


### PR DESCRIPTION
This allows using ExecuteAsync for plot commands (next, previous, delete, resize) instead of interactions, by making sure that the plot is sent to the IDE before the R functions for those commands return.

Changes the plot message to include the state (active, count), to avoid having the IDE call back immediately to query that info.

Changes are required on the VS side, I will wait to merge until those are ready.