### PR TITLE
Fix #1897: Remove CRT dependency for Dev15

### DIFF
--- a/src/Microsoft.R.Host.vcxproj
+++ b/src/Microsoft.R.Host.vcxproj
@@ -101,6 +101,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>..\lib\picojson;..\lib\websocketpp</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -118,6 +119,7 @@
       <PreprocessorDefinitions>TRACE_JSON;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>..\lib\picojson;..\lib\websocketpp</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -137,6 +139,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>..\lib\picojson;..\lib\websocketpp</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -158,6 +161,7 @@
       <PreprocessorDefinitions>TRACE_JSON;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>false</SDLCheck>
       <AdditionalIncludeDirectories>..\lib\picojson;..\lib\websocketpp</AdditionalIncludeDirectories>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -561,7 +561,7 @@ namespace rhost {
             }
         }
 
-        extern "C" int ReadConsole(const char* prompt, char* buf, int len, int addToHistory) {
+        extern "C" int R_ReadConsole(const char* prompt, char* buf, int len, int addToHistory) {
             return with_cancellation([&] {
                 if (!allow_intr_in_CallBack) {
                     // If we got here, this means that we've just processed a cancellation request that had
@@ -880,7 +880,7 @@ namespace rhost {
         }
 
         void register_callbacks(structRstart& rp) {
-            rp.ReadConsole = ReadConsole;
+            rp.ReadConsole = R_ReadConsole;
             rp.WriteConsoleEx = WriteConsoleEx;
             rp.CallBack = CallBack;
             rp.ShowMessage = ShowMessage;


### PR DESCRIPTION
Statically link the runtime.