### PR TITLE
Host can send binary blobs.

### DIFF
--- a/src/Microsoft.R.Host.vcxproj
+++ b/src/Microsoft.R.Host.vcxproj
@@ -174,6 +174,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="blobs.cpp" />
     <ClCompile Include="exports.cpp" />
     <ClCompile Include="grdeviceside.cpp" />
     <ClCompile Include="grdevicesxaml.cpp" />
@@ -188,6 +189,7 @@
     <ClCompile Include="util.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="blobs.h" />
     <ClInclude Include="detours.h" />
     <ClInclude Include="exports.h" />
     <ClInclude Include="grdevices.h" />

--- a/src/Microsoft.R.Host.vcxproj.filters
+++ b/src/Microsoft.R.Host.vcxproj.filters
@@ -13,6 +13,7 @@
     <ClCompile Include="grdevicesxaml.cpp" />
     <ClCompile Include="grdeviceside.cpp" />
     <ClCompile Include="json.cpp" />
+    <ClCompile Include="blobs.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
@@ -32,6 +33,7 @@
     <ClInclude Include="grdevicesxaml.h" />
     <ClInclude Include="grdeviceside.h" />
     <ClInclude Include="json.h" />
+    <ClInclude Include="blobs.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/Rapi.h
+++ b/src/Rapi.h
@@ -151,6 +151,8 @@ extern "C" {
         double i;
     } Rcomplex;
 
+    typedef unsigned char Rbyte;
+
     typedef void(*R_CFinalizer_t)(SEXP);
     typedef int(*blah1) (const char *, char *, int, int);
     typedef void(*blah2) (const char *, int);
@@ -372,6 +374,7 @@ extern "C" {
     extern int* LOGICAL(SEXP x);
     extern int* INTEGER(SEXP x);
     extern double* REAL(SEXP x);
+    extern Rbyte* RAW(SEXP x);
 
     extern int IS_UTF8(SEXP x);
 

--- a/src/blobs.cpp
+++ b/src/blobs.cpp
@@ -1,0 +1,85 @@
+
+/* ****************************************************************************
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+*
+*
+* This file is part of Microsoft R Host.
+*
+* Microsoft R Host is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 2 of the License, or
+* (at your option) any later version.
+*
+* Microsoft R Host is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Microsoft R Host.  If not, see <http://www.gnu.org/licenses/>.
+*
+* ***************************************************************************/
+
+#include "blobs.h"
+#include "log.h"
+
+using namespace rhost::util;
+using namespace rhost::log;
+namespace js = picojson;
+
+namespace rhost {
+    namespace raw {
+        namespace {
+            void blob_error(SEXP sexp, const char* format, ...) {
+                SEXP repr_sexp = STRING_ELT(Rf_deparse1line(sexp, R_FALSE), 0);
+                Rf_protect(repr_sexp);
+                const char* repr = R_CHAR(repr_sexp);
+
+                char buf[0x10000] = {};
+                snprintf(buf, sizeof buf, "BLOB serialization failed for input:\n\n%s\n\n", repr);
+
+                size_t len = strlen(buf);
+                va_list va;
+                va_start(va, format);
+                vsnprintf(buf + len, sizeof buf - len, format, va);
+                va_end(format);
+
+                Rf_error("%s", buf);
+            }
+
+            void at_most_one(SEXP sexp) {
+                if (Rf_length(sexp) != 1) {
+                    blob_error(sexp, "Vector must have 0 or 1 elements.");
+                }
+            }
+
+            bool to_blobs_internal(SEXP sexp, rhost::util::blobs& blobs, picojson::value& json) {
+                int type = TYPEOF(sexp);
+                size_t length = Rf_length(sexp);
+
+                if ((type == NILSXP) || (length == 0)) {
+                    json = js::value();
+                    return true;
+                }
+
+                if ((type == RAWSXP) || (length == 0)) {
+                    Rbyte* data = RAW(sexp);
+                    size_t length = Rf_length(sexp);
+                    json = js::value();
+                    rhost::util::append(blobs, blob(data, length));
+                    return true;
+                }
+
+                blob_error(sexp, "Unsupported type for blob - must be one of: NULL; raw.");
+                return false;
+            }
+        }
+
+        bool to_blobs(SEXP sexp, rhost::util::blobs& blobs, js::value& json) {
+            bool result = false;
+            rhost::util::errors_to_exceptions([&] {result = to_blobs_internal(sexp, blobs, json); });
+            return result;
+        }
+    }
+}

--- a/src/blobs.cpp
+++ b/src/blobs.cpp
@@ -1,4 +1,3 @@
-
 /* ****************************************************************************
 *
 * Copyright (c) Microsoft Corporation. All rights reserved.
@@ -48,37 +47,29 @@ namespace rhost {
                 Rf_error("%s", buf);
             }
 
-            void at_most_one(SEXP sexp) {
-                if (Rf_length(sexp) != 1) {
-                    blob_error(sexp, "Vector must have 0 or 1 elements.");
-                }
-            }
-
-            bool to_blobs_internal(SEXP sexp, rhost::util::blobs& blobs, picojson::value& json) {
+            bool to_blob_internal(SEXP sexp, rhost::util::blob& blob) {
                 int type = TYPEOF(sexp);
                 size_t length = Rf_length(sexp);
 
                 if ((type == NILSXP) || (length == 0)) {
-                    json = js::value();
                     return true;
                 }
 
                 if ((type == RAWSXP) || (length == 0)) {
                     Rbyte* data = RAW(sexp);
-                    size_t length = Rf_length(sexp);
-                    json = js::value();
-                    rhost::util::append(blobs, blob(data, length));
+                    size_t size = Rf_length(sexp);
+                    blob.push_back(rhost::util::blob_slice(data, data + size));
                     return true;
                 }
 
-                blob_error(sexp, "Unsupported type for blob - must be one of: NULL; raw.");
+                blob_error(sexp, "Unsupported type for blob - must be one of: NULL; RAW.");
                 return false;
             }
         }
 
-        bool to_blobs(SEXP sexp, rhost::util::blobs& blobs, js::value& json) {
+        bool to_blob(SEXP sexp, rhost::util::blob& blob) {
             bool result = false;
-            rhost::util::errors_to_exceptions([&] {result = to_blobs_internal(sexp, blobs, json); });
+            rhost::util::errors_to_exceptions([&] {result = to_blob_internal(sexp, blob); });
             return result;
         }
     }

--- a/src/blobs.h
+++ b/src/blobs.h
@@ -1,4 +1,3 @@
-#pragma once
 /* ****************************************************************************
 *
 * Copyright (c) Microsoft Corporation. All rights reserved.
@@ -35,6 +34,6 @@ namespace rhost {
         //
         // Returns true if serialized value was NA, and false otherwise (even if it contains NA somewhere inside).
         // Errors are reported via Rf_error.
-        bool to_blobs(SEXP sexp, rhost::util::blobs& blobs, picojson::value& result);
+        bool to_blob(SEXP sexp, rhost::util::blob& blobs);
     }
 }

--- a/src/blobs.h
+++ b/src/blobs.h
@@ -1,0 +1,40 @@
+#pragma once
+/* ****************************************************************************
+*
+* Copyright (c) Microsoft Corporation. All rights reserved.
+*
+*
+* This file is part of Microsoft R Host.
+*
+* Microsoft R Host is free software: you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation, either version 2 of the License, or
+* (at your option) any later version.
+*
+* Microsoft R Host is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with Microsoft R Host.  If not, see <http://www.gnu.org/licenses/>.
+*
+* ***************************************************************************/
+
+#pragma once
+#include "stdafx.h"
+#include "util.h"
+#include "Rapi.h"
+
+namespace rhost {
+    namespace raw {
+        // Produces BLOB(raw bytes)-JSON from an R object according to the following mappings:
+        //
+        // NULL, NA, empty vector -> null
+        // RAW -> bytes
+        //
+        // Returns true if serialized value was NA, and false otherwise (even if it contains NA somewhere inside).
+        // Errors are reported via Rf_error.
+        bool to_blobs(SEXP sexp, rhost::util::blobs& blobs, picojson::value& result);
+    }
+}

--- a/src/grdeviceside.cpp
+++ b/src/grdeviceside.cpp
@@ -709,34 +709,19 @@ namespace rhost {
                 auto path_copy(filename);
                 rhost::host::with_cancellation([&] {
                     std::string file_path = path_copy.make_preferred().string();
-                    rhost::util::blobs data;
-                    char* plot_image_data = nullptr;
-                    size_t size = 0;
+                    rhost::util::blob plot_image_data;
 
                     if (file_path.length() > 0) {
-                        // Send actual plot image as Binary
-                        std::ifstream plot_file_stream(file_path, std::ios::binary | std::ios::ate);
-                        std::ifstream::pos_type file_end = plot_file_stream.tellg();
-                        plot_image_data = new char[file_end];
-                        plot_file_stream.seekg(0, std::ios::beg);
-                        plot_file_stream.read(plot_image_data, file_end);
-                        size = static_cast<size_t>(file_end);
-                        plot_file_stream.close();
+                        rhost::util::append_from_file(plot_image_data, file_path);
                     }
-
-                    rhost::util::append(data, rhost::util::blob(static_cast<void*>(plot_image_data), size));
 
                     rhost::host::send_notification(
                         "!Plot",
-                        data,
+                        plot_image_data,
                         rhost::util::to_utf8(file_path),
                         static_cast<double>(active_plot_index()),
                         static_cast<double>(plot_count())
                     );
-
-                    if (plot_image_data) {
-                        delete[size] plot_image_data;
-                    }
                 });
             }
 

--- a/src/host.h
+++ b/src/host.h
@@ -31,6 +31,7 @@ namespace rhost {
             std::string id;
             std::string request_id; // not a response if empty
             std::string name;
+            size_t blob_count;
             picojson::array args;
         };
 
@@ -62,6 +63,7 @@ namespace rhost {
             }
         }
 
+        std::string send_notification(const char* name, const rhost::util::blobs& blobs, const picojson::array& args);
         std::string send_notification(const char* name, const picojson::array& args);
 
         template<class... Args>
@@ -69,6 +71,13 @@ namespace rhost {
             picojson::array args_array;
             rhost::util::append(args_array, args...);
             return send_notification(name, args_array);
+        }
+
+        template<class... Args>
+        inline std::string send_notification(const char* name, const rhost::util::blobs& blobs, const Args&... args) {
+            picojson::array args_array;
+            rhost::util::append(args_array, args...);
+            return send_notification(name, blobs, args_array);
         }
 
         message send_request_and_get_response(const char* name, const picojson::array& args);

--- a/src/host.h
+++ b/src/host.h
@@ -63,7 +63,7 @@ namespace rhost {
             }
         }
 
-        std::string send_notification(const char* name, const rhost::util::blobs& blobs, const picojson::array& args);
+        std::string send_notification(const char* name, const rhost::util::blob& blob, const picojson::array& args);
         std::string send_notification(const char* name, const picojson::array& args);
 
         template<class... Args>
@@ -74,10 +74,10 @@ namespace rhost {
         }
 
         template<class... Args>
-        inline std::string send_notification(const char* name, const rhost::util::blobs& blobs, const Args&... args) {
+        inline std::string send_notification(const char* name, const rhost::util::blob& blob, const Args&... args) {
             picojson::array args_array;
             rhost::util::append(args_array, args...);
-            return send_notification(name, blobs, args_array);
+            return send_notification(name, blob, args_array);
         }
 
         message send_request_and_get_response(const char* name, const picojson::array& args);

--- a/src/util.h
+++ b/src/util.h
@@ -117,19 +117,14 @@ namespace rhost {
             }
         };
 
-        struct blob {
-            void* raw_data;
-            size_t length;
+        typedef std::vector<byte> blob_slice;
+        typedef std::vector<blob_slice> blob;
 
-            blob() :
-                raw_data(nullptr), length(0) {}
-            blob(void* const data, const size_t size) :
-                raw_data(data), length(size) {}
-
-            inline bool is_empty() { return (!raw_data) || (!length); }
-        };
-
-        typedef std::vector<blob> blobs;
+        inline void append_from_file(blob& blob, const std::string& path) {
+            std::ifstream ifs(path, std::ios::binary | std::ios::in);
+            std::noskipws(ifs);
+            blob.push_back(blob_slice(std::istream_iterator<byte>(ifs), std::istream_iterator<byte>()));
+        }
 
         std::string to_utf8(const char* buf, size_t len);
 
@@ -155,17 +150,6 @@ namespace rhost {
         template<class Arg, class... Args>
         inline void append(picojson::array& msg, Arg&& arg, Args&&... args) {
             msg.push_back(picojson::value(std::forward<Arg>(arg)));
-            append(msg, std::forward<Args>(args)...);
-        }
-
-        template<class Arg>
-        inline void append(rhost::util::blobs& msg, Arg&& arg) {
-            msg.push_back(rhost::util::blob(std::forward<Arg>(arg)));
-        }
-
-        template<class Arg, class... Args>
-        inline void append(rhost::util::blobs& msg, Arg&& arg, Args&&... args) {
-            msg.push_back(rhost::util::blob(std::forward<Arg>(arg)));
             append(msg, std::forward<Args>(args)...);
         }
 

--- a/src/util.h
+++ b/src/util.h
@@ -117,6 +117,20 @@ namespace rhost {
             }
         };
 
+        struct blob {
+            void* raw_data;
+            size_t length;
+
+            blob() :
+                raw_data(nullptr), length(0) {}
+            blob(void* const data, const size_t size) :
+                raw_data(data), length(size) {}
+
+            inline bool is_empty() { return (!raw_data) || (!length); }
+        };
+
+        typedef std::vector<blob> blobs;
+
         std::string to_utf8(const char* buf, size_t len);
 
         inline std::string to_utf8(const std::string& s) {
@@ -144,6 +158,16 @@ namespace rhost {
             append(msg, std::forward<Args>(args)...);
         }
 
+        template<class Arg>
+        inline void append(rhost::util::blobs& msg, Arg&& arg) {
+            msg.push_back(rhost::util::blob(std::forward<Arg>(arg)));
+        }
+
+        template<class Arg, class... Args>
+        inline void append(rhost::util::blobs& msg, Arg&& arg, Args&&... args) {
+            msg.push_back(rhost::util::blob(std::forward<Arg>(arg)));
+            append(msg, std::forward<Args>(args)...);
+        }
 
         // A C++-friendly helper for Rf_error. Invoking Rf_error directly is not a good idea, because
         // it performs a longjmp, which will skip all C++ destructors when unwinding stack frames - so

--- a/src/util.h
+++ b/src/util.h
@@ -127,20 +127,20 @@ namespace rhost {
                     fclose(fp);
                 }
             });
-            
+
             fp = fopen(path.c_str(), "rb");
             if (fp) {
                 fseek(fp, 0, SEEK_END);
                 size_t len = ftell(fp);
-				blob_slice *slice = new blob_slice(len);
+                blob_slice slice(len);
                 fseek(fp, 0, SEEK_SET);
-				if (len) {
-					size_t read = fread(static_cast<void*>(&(*slice)[0]), sizeof(byte), len, fp);
-					if (read != len) {
-						throw std::exception("Error reading file");
-					}
-				}
-                blob.push_back(*slice);
+                if (len) {
+                    size_t read = fread(&slice[0], sizeof(byte), len, fp);
+                    if (read != len) {
+                        throw std::exception("Error reading file");
+                    }
+                }
+                blob.push_back(std::move(slice));
             }
         }
 


### PR DESCRIPTION
Host can send binary blobs. Plots updated to use blobs. Added =r (raw…) eval kind. First element in the message json now has the header [id, name, blob_count, <optional>request_id].

see https://github.com/Microsoft/RTVS/issues/2023