### PR TITLE
Adds feature to create and send binary blobs to RHost 

### DIFF
--- a/src/Rapi.h
+++ b/src/Rapi.h
@@ -322,6 +322,13 @@ extern "C" {
     extern SEXP Rf_NewEnvironment(SEXP, SEXP, SEXP);
     extern SEXP Rf_getAttrib(SEXP, SEXP);
 
+    extern SEXP Rf_ScalarComplex(Rcomplex);
+    extern SEXP Rf_ScalarInteger(int);
+    extern SEXP Rf_ScalarLogical(int);
+    extern SEXP Rf_ScalarRaw(Rbyte);
+    extern SEXP Rf_ScalarReal(double);
+    extern SEXP Rf_ScalarString(SEXP);
+
     typedef enum {
         CE_NATIVE = 0,
         CE_UTF8 = 1,

--- a/src/blobs.cpp
+++ b/src/blobs.cpp
@@ -55,10 +55,9 @@ namespace rhost {
                     return true;
                 }
 
-                if ((type == RAWSXP) || (length == 0)) {
+                if (type == RAWSXP) {
                     Rbyte* data = RAW(sexp);
-                    size_t size = Rf_length(sexp);
-                    blob.push_back(rhost::util::blob_slice(data, data + size));
+                    blob.push_back(rhost::util::blob_slice(data, data + length));
                     return true;
                 }
 

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -127,8 +127,8 @@ namespace rhost {
         std::queue<message> binary_message_queue;
         std::mutex binary_message_queue_mutex;
 
-        long long next_blob_id = 0;
-        std::map<long long, rhost::util::blob> received_blobs;
+        int next_blob_id = 0;
+        std::map<int, rhost::util::blob> received_blobs;
         std::mutex received_blobs_mutex;
 
         void terminate_if_closed() {
@@ -292,15 +292,22 @@ namespace rhost {
 
             {
                 std::lock_guard<std::mutex> lock(received_blobs_mutex);
-                long long blob_id = ++next_blob_id;
+                int blob_id = ++next_blob_id;
                 received_blobs[blob_id] = msg.blob;
                 respond_to_message(msg, static_cast<double>(blob_id));
             }
         }
 
-        const std::vector<byte> get_blob(long long blob_id) {
-            std::map<long long, rhost::util::blob>::iterator res = received_blobs.find(blob_id);
-            std::vector<byte> data;
+        int create_blob(const rhost::util::blob& blob) {
+            std::lock_guard<std::mutex> lock(received_blobs_mutex);
+            int blob_id = ++next_blob_id;
+            received_blobs[blob_id] = blob;
+            return blob_id;
+        }
+
+        const blob_slice get_blob_as_single_slice(int blob_id) {
+            std::map<int, rhost::util::blob>::iterator res = received_blobs.find(blob_id);
+            blob_slice data;
 
             if (res == received_blobs.end()) {
                 return data;
@@ -314,9 +321,35 @@ namespace rhost {
             return data;
         }
 
-        void destroy_blob(long long blob_id) {
+        void get_blobs(const message& msg) {
+            assert(msg.name == "?GetBlob");
+
+            blob blob;
+            picojson::array blob_ids;
+            for (int i = 0; i < msg.args.size(); ++i) {
+                int blob_id = static_cast<int>(msg.args[i].get<double>());
+                blob_slice slice = get_blob_as_single_slice(blob_id);
+                if (slice.size() > 0) {
+                    blob.push_back(slice);
+                    rhost::util::append(blob_ids, static_cast<double>(blob_id));
+                }
+            }
+
+            respond_to_message(msg, blob, blob_ids);
+        }
+
+        void destroy_blob(int blob_id) {
             std::lock_guard<std::mutex> lock(received_blobs_mutex);
             received_blobs.erase(blob_id);
+        }
+
+        void destroy_blobs(const message& msg) {
+            assert(msg.name == "!DestroyBlob");
+            std::lock_guard<std::mutex> lock(received_blobs_mutex);
+            for (int i = 0; i < msg.args.size(); ++i) {
+                int blob_id = static_cast<int>(msg.args[i].get<double>());
+                received_blobs.erase(blob_id);
+            }
         }
 
         void handle_eval(const message& msg) {
@@ -867,8 +900,11 @@ namespace rhost {
             } else if (incoming.name == "?CreateBlob") {
                 std::lock_guard<std::mutex> lock(binary_message_queue_mutex);
                 binary_message_queue.push(incoming);
-                unblock_message_loop();
                 return;
+            } else if (incoming.name == "?GetBlob") {
+                return get_blobs(incoming);
+            } else if (incoming.name == "!DestroyBlob") {
+                return destroy_blobs(incoming);
             } else if (incoming.name.size() >= 2 && incoming.name[0] == '?' && incoming.name[1] == '=') {
                 std::lock_guard<std::mutex> lock(eval_requests_mutex);
                 eval_requests.push(incoming);
@@ -902,8 +938,6 @@ namespace rhost {
                 create_blob(incoming);
                 binary_message_queue.pop();
              }
-
-            unblock_message_loop();
         }
 
         void ws_message_handler(websocketpp::connection_hdl hdl, ws_connection_type::message_ptr msg) {

--- a/src/host.cpp
+++ b/src/host.cpp
@@ -937,7 +937,7 @@ namespace rhost {
 
             message incoming = binary_message_queue.front();
             const auto& raw = msg->get_raw_payload();
-            incoming.blob.emplace_back(rhost::util::blob_slice(raw.data(), raw.data() + raw.size()));
+            incoming.blob.emplace_back(raw.data(), raw.data() + raw.size());
 
             if (incoming.blob_count == incoming.blob.size()) {
                 create_blob(incoming);

--- a/src/host.h
+++ b/src/host.h
@@ -90,7 +90,8 @@ namespace rhost {
             return send_request_and_get_response(name, args_array);
         }
 
-        const std::vector<byte> get_blob(long long id);
-        void destroy_blob(long long id);
+        int create_blob(const rhost::util::blob& blob);
+        const rhost::util::blob_slice get_blob_as_single_slice(int id);
+        void destroy_blob(int id);
     }
 }

--- a/src/host.h
+++ b/src/host.h
@@ -32,6 +32,7 @@ namespace rhost {
             std::string request_id; // not a response if empty
             std::string name;
             size_t blob_count;
+            rhost::util::blob blob;
             picojson::array args;
         };
 
@@ -88,5 +89,8 @@ namespace rhost {
             rhost::util::append(args_array, args...);
             return send_request_and_get_response(name, args_array);
         }
+
+        const std::vector<byte> get_blob(long long id);
+        void destroy_blob(long long id);
     }
 }

--- a/src/r_util.cpp
+++ b/src/r_util.cpp
@@ -441,6 +441,27 @@ namespace rhost {
             return result;
         }
 
+        extern "C" SEXP get_blob(SEXP id) {
+            int blob_id = Rf_asInteger(id);
+            const std::vector<byte> data = rhost::host::get_blob(blob_id);
+
+            if (data.size() == 0) {
+                return R_NilValue;
+            }
+
+            SEXP rawVector = Rf_allocVector(RAWSXP, data.size());
+            Rbyte* dest = RAW(rawVector);
+            memcpy_s(dest, data.size(), data.data(), data.size());
+
+            return rawVector;
+        }
+
+        extern "C" SEXP delete_blob(SEXP id) {
+            int blob_id = Rf_asInteger(id);
+            rhost::host::destroy_blob(blob_id);
+            return R_NilValue;
+        }
+
         R_CallMethodDef call_methods[] = {
             { "Microsoft.R.Host::Call.unevaluated_promise", (DL_FUNC)unevaluated_promise, 2 },
             { "Microsoft.R.Host::Call.memory_connection", (DL_FUNC)memory_connection_new, 4 },
@@ -453,6 +474,8 @@ namespace rhost {
             { "Microsoft.R.Host::Call.set_rdebug", (DL_FUNC)set_rdebug, 2 },
             { "Microsoft.R.Host::Call.browser_set_debug", (DL_FUNC)browser_set_debug, 2 },
             { "Microsoft.R.Host::Call.toJSON", (DL_FUNC)toJSON, 1 },
+            { "Microsoft.R.Host::Call.get_blob", (DL_FUNC)get_blob, 1 },
+            { "Microsoft.R.Host::Call.delete_blob", (DL_FUNC)delete_blob, 1 },
             { }
         };
 

--- a/src/r_util.cpp
+++ b/src/r_util.cpp
@@ -464,10 +464,11 @@ namespace rhost {
                 return R_NilValue;
             }
 
-            SEXP rawVector = Rf_allocVector(RAWSXP, data.size());
+            SEXP rawVector = nullptr;
+            Rf_protect(rawVector = Rf_allocVector(RAWSXP, data.size()));
             Rbyte* dest = RAW(rawVector);
             memcpy_s(dest, data.size(), data.data(), data.size());
-
+            Rf_unprotect(1);
             return rawVector;
         }
 


### PR DESCRIPTION
This change has following features related to blobs : [2065](https://github.com/Microsoft/RTVS/issues/2065)
1. RHost now supports receiving blobs in batches.
2. Adds protocol changes to support creation, access, and deletion of blobs in batches.
3. Blobs can be created, accessed, and destroyed from R
