### PR TITLE
Support for multiple ide devices.

### DIFF
--- a/src/grdeviceside.cpp
+++ b/src/grdeviceside.cpp
@@ -1144,7 +1144,7 @@ namespace rhost {
 
                 return rhost::util::exceptions_to_errors([&] {
                     auto source_dev = find_device_by_id(source_device_id);
-                    if (source_dev != nullptr) {
+                    if (source_dev == nullptr) {
                         throw rhost::util::r_error("Source device could not be found.");
                     }
 

--- a/src/grdeviceside.cpp
+++ b/src/grdeviceside.cpp
@@ -397,14 +397,7 @@ namespace rhost {
             }
 
             void plot_history::remove(const boost::uuids::uuid& plot_id) {
-                std::vector<std::unique_ptr<plot>>::iterator plot = _plots.end();
-                for (auto it = _plots.begin(); it != _plots.end(); ++it) {
-                    if ((*it)->get_id() == plot_id) {
-                        plot = it;
-                        break;
-                    }
-                }
-
+                auto plot = find_if(_plots.begin(), _plots.end(), [&](auto& p) { return p->get_id() == plot_id; });
                 if (plot != _plots.end()) {
                     _active_plot = _plots.erase(plot);
                     // erase() returns an iterator that points to end() when removing the last item


### PR DESCRIPTION
Add message for device creation to initialize new ide devices with the correct resolution, so that the first plot command on a new device renders to the exact size of the plot window, instead of rendering to default size and then having to resize immediately.
Add message for device destruction so that IDE can track lifetime of devices.
Add more info to the plot message, to identify the device it comes from as well as a unique plot id.
Add ability to remove any plot, not just the 'current'.
Add ability to copy a plot from a device to another.
