### PR TITLE
Set enable dpi awareness in manifest so that plots in the windows dev…

### DIFF
--- a/src/Microsoft.R.Host.vcxproj
+++ b/src/Microsoft.R.Host.vcxproj
@@ -131,6 +131,9 @@
       <AdditionalDependencies>R.lib;Rgraphapp.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;dbghelp.lib;Rstrtmgr.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <StackReserveSize>20971520</StackReserveSize>
     </Link>
+    <Manifest>
+      <EnableDpiAwareness>true</EnableDpiAwareness>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -180,6 +183,9 @@
       <EntryPointSymbol>mainCRTStartup</EntryPointSymbol>
       <StackReserveSize>20971520</StackReserveSize>
     </Link>
+    <Manifest>
+      <EnableDpiAwareness>true</EnableDpiAwareness>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="blobs.cpp" />


### PR DESCRIPTION
…ice aren't blurry.

https://github.com/Microsoft/RTVS/issues/2018
