### PR TITLE
Session management and reconnection (R-Host)

### DIFF
--- a/src/Rapi.h
+++ b/src/Rapi.h
@@ -258,6 +258,8 @@ extern "C" {
     extern void Rf_KillAllDevices(void);
     extern void R_CleanTempDir(void);
     extern void R_SaveGlobalEnv(void);
+    extern void R_SaveGlobalEnvToFile(const char*);
+    extern void R_RestoreGlobalEnvFromFile(const char*, Rboolean);
     extern SEXP R_ParseVector(SEXP, int, ParseStatus*, SEXP);
     extern SEXP R_tryEval(SEXP, SEXP, int*);
     extern SEXP R_tryEvalSilent(SEXP, SEXP, int*);
@@ -435,6 +437,7 @@ extern "C" {
     void R_WaitEvent();
     void R_ProcessEvents();
     void R_Suicide(const char *);
+    void R_CleanUp(SA_TYPE saveact, int status, int runLast);
 
     typedef SEXP(*CCODE)(SEXP, SEXP, SEXP, SEXP);
 

--- a/src/host.h
+++ b/src/host.h
@@ -33,8 +33,8 @@ namespace rhost {
         class eval_cancel_error : std::exception {
         };
 
-        void initialize(structRstart& rp);
-        void terminate_if_closed();
+        void initialize(structRstart& rp, const fs::path& rdata, std::chrono::seconds idle_timeout);
+        void shutdown_if_requested();
 
         extern "C" void ShowMessage(const char* s);
         extern "C" int YesNoCancel(const char* s);
@@ -48,7 +48,7 @@ namespace rhost {
 
         template <class F>
         auto with_cancellation(F body) -> decltype(body()) {
-            terminate_if_closed();
+            shutdown_if_requested();
             try {
                 return body();
             } catch (const eval_cancel_error&) {

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -230,8 +230,6 @@ namespace rhost {
                     msgbox_text += c;
                 }
                 
-                //MessageBoxA(HWND_DESKTOP, msgbox_text.c_str(), "Microsoft R Host Process fatal error", MB_OK | MB_ICONERROR);
-
                 // Raise and catch an exception so that minidump with a stacktrace can be produced from it.
                 [&] {
                     terminate_mutex.unlock();
@@ -243,7 +241,7 @@ namespace rhost {
                 }();
             }
             
-            R_Suicide(message);
+            R_CleanUp(SA_NOSAVE, (unexpected ? EXIT_FAILURE : EXIT_SUCCESS), 0);
         }
 
         void terminate(const char* format, ...) {

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -28,6 +28,8 @@
 #include <atomic>
 #include <cinttypes>
 #include <codecvt>
+#include <chrono>
+#include <condition_variable>
 #include <csetjmp>
 #include <cstdio>
 #include <cstdlib>
@@ -82,4 +84,4 @@
 
 #include "zip.h"
 
-namespace fs = std::experimental::filesystem;
+namespace fs = std::tr2::sys;


### PR DESCRIPTION
Add the ability to load R state from Rdata on startup, and save it on graceful shutdown.

Add a protocol message to request shutdown with or without saving state.

Refactor host termination message: now only used on graceful shutdown to indicate whether state was saved or not.

Add the ability to specify idle timeout, and automatically shutdown the process and save state when it's triggered.

Fix race condition between evaluating R code, and R loading the standard library on startup.

Fix logging verbosity not parsed from command line arguments.