### PR TITLE
eventloop.h is not available on windows

### DIFF
--- a/src/r_api.h
+++ b/src/r_api.h
@@ -48,12 +48,15 @@
 #undef class
 #undef private
 
-#include "R_ext/eventloop.h"
 #include "R_ext/Rdynload.h"
 #include "R_ext/RStartup.h"
 #include "R_ext/Parse.h"
 #include "R_ext/GraphicsEngine.h"
 #include "R_ext/GraphicsDevice.h"
+
+#ifndef _WIN32
+#include "R_ext/eventloop.h"
+#endif
 
 #define R_FALSE Rboolean::FALSE
 #define R_TRUE Rboolean::TRUE


### PR DESCRIPTION
Build fails on windows:
```
2>G:/GIT/RTVS/src/Host/Process/src/r_api.h:51:29: fatal error: R_ext/eventloop.h: No such file or directory
2> #include "R_ext/eventloop.h"
2>                             ^
2>compilation terminated.
2>make[2]: *** [CMakeFiles/Microsoft.R.Host.dir/build.make:64: CMakeFiles/Microsoft.R.Host.dir/src/blobs.cpp.obj] Error 1
2>make[1]: *** [CMakeFiles/Makefile2:68: CMakeFiles/Microsoft.R.Host.dir/all] Error 2
2>make: *** [Makefile:84: all] Error 2
```